### PR TITLE
Add x32 support, move all configuration into tomls

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OBS-to-XAir
 
-This is a small script that mutes and unmutes channels on Behringer XAir Mixers depending on the current scene.
+This is a small script that mutes, unmutes and toggles groups of channels on Behringer XAir Mixers depending on the current scene.
 
 ## Requirements
 
@@ -29,9 +29,9 @@ pip install .
 
 -   Open the included `config.toml` and set OBS host, port and password as well as the xair mixers ip.
 
-    -   You may also set the kind of mixer in the script. (`XR12, XR16, XR18, MR18`)
+    -   You may also set the kind of mixer in the script. (`XR12, XR16, XR18, MR18, X32`)
 
--   Set the scene to channel mutes mapping in the script.
+-   Set the scene to channel mutes mapping in `mapping.toml`.
 
 ## Usage
 
@@ -49,7 +49,7 @@ This script was developed and tested with:
 
 -   OBS 28.01
 -   obs-websocket 5.0.1
--   A Behringer XR18 and Midas MR18
+-   A Midas MR18 and an X32 emulator.
 
 ## Special Thanks
 

--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ pip install .
 
 -   Configure websocket settings within `OBS->Tools->obs-websocket Settings`
 
--   Open the included `config.toml` and set OBS host, port and password as well as the xair mixers ip.
+-   Open the included `config.toml` and set OBS host, port and password as well as the xair mixers kind and ip.
 
-    -   You may also set the kind of mixer in the script. (`XR12, XR16, XR18, MR18, X32`)
+    -   Mixer kind may be any one of (`XR12, XR16, XR18, MR18, X32`)
 
 -   Set the scene to channel mutes mapping in `mapping.toml`.
 

--- a/__main__.py
+++ b/__main__.py
@@ -1,14 +1,25 @@
+import logging
 import time
+from pathlib import Path
 
 import obsws_python as obs
 import xair_api
 
-mapping = {
-    "START": 1,
-    "BRB": 2,
-    "END": 3,
-    "LIVE": 4,
-}  # set the mapping for the scene to channel mapping here. "scenename": "channel"
+try:
+    import tomllib
+except ModuleNotFoundError:
+    import tomli as tomllib
+
+logging.basicConfig(level=logging.disable())
+
+
+def _get_mapping():
+    filepath = Path.cwd() / "mapping.toml"
+    with open(filepath, "rb") as f:
+        return tomllib.load(f)
+
+
+mapping = _get_mapping()
 
 
 class Observer:
@@ -28,10 +39,20 @@ class Observer:
         print(" ".join(info))
 
     def on_current_program_scene_changed(self, data):
+        def ftoggle(i):
+            self._mixer.strip[i - 1].mix.on = not self._mixer.strip[i - 1].mix.on
+
+        def fset(i, is_muted):
+            self._mixer.strip[i - 1].mix.on = is_muted
+
         scene = data.scene_name
         print(f"Switched to scene {scene}")
-        for k, v in mapping.items():
-            self._mixer.strip[v - 1].mix.on = k == scene
+        if map_ := mapping.get(scene):
+            for key in map_.keys():
+                if key == "toggle":
+                    [ftoggle(i) for i in map_[key]]
+                else:
+                    [fset(i, key == "mute") for i in map_[key]]
 
     def on_exit_started(self, _):
         print("OBS closing")
@@ -40,6 +61,8 @@ class Observer:
 
 
 def main():
+    kind_mixer = "XR18"
+
     with xair_api.connect(kind_mixer) as mixer:
         o = Observer(mixer)
 
@@ -48,6 +71,4 @@ def main():
 
 
 if __name__ == "__main__":
-    kind_mixer = "XR18"
-
     main()

--- a/__main__.py
+++ b/__main__.py
@@ -61,7 +61,9 @@ class Observer:
 
 
 def main():
-    kind_mixer = "XR18"
+    filepath = Path.cwd() / "config.toml"
+    with open(filepath, "rb") as f:
+        kind_mixer = tomllib.load(f)["connection"].get("mixer")
 
     with xair_api.connect(kind_mixer) as mixer:
         o = Observer(mixer)

--- a/config.toml
+++ b/config.toml
@@ -4,5 +4,6 @@ host = "localhost"
 port = 4455
 password = "strongpassword"
 
-# xair mixer ip
+# mixer kind and ip
+mixer = "XR18"
 ip = "mixer.local"

--- a/mapping.toml
+++ b/mapping.toml
@@ -1,0 +1,9 @@
+START.mute = [1, 3, 5]
+START.unmute = [2, 7]
+
+BRB.mute = [2, 7]
+BRB.unmute = [1, 3, 5]
+
+END.toggle = [12, 14]
+
+LIVE.toggle = [16]

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,10 @@ setup(
     name="xair-obs",
     version="0.0.1",
     description="Syncs Xair states to OBS scenes",
-    install_requires=["obsws-python", "xair-api"],
+    install_requires=[
+        "obsws-python",
+        "xair-api",
+        "tomli >= 2.0.1;python_version < '3.11'",
+    ],
     python_requires=">=3.10",
 )


### PR DESCRIPTION
Hi lebaston!

Thanks for your previous feedback. This PR introduces the following updates:

- support for x32 mixer
- mapping and mixer kind configuration moved into toml files.
- script now mutes/unmutes or toggles groups of strips according to mapping.toml

Testing for X32 was done with an emulator but that should suffice.
No mention of logging module in README but I've added into script for the curious.